### PR TITLE
remove abstract 2x1 and 2x2 so character won't learn more recipes than it should

### DIFF
--- a/effectoncondition/recipe_unlocks/abstract.json
+++ b/effectoncondition/recipe_unlocks/abstract.json
@@ -14,10 +14,14 @@
           "EOC_ANALYZER_TYRANNOSAURUS_FOSSIL",
           "EOC_ANALYZER_XIPHACTINUS_FOSSIL",
           "EOC_ANALYZER_JAPANESE_KNOTWEED",
+          "EOC_ANALYZER_JAPANESE_KNOTWEED_2",
           "EOC_ANALYZER_BLACK_EYED_SUSAN",
           "EOC_ANALYZER_CHAMOMILE",
+          "EOC_ANALYZER_CHAMOMILE_2",
           "EOC_ANALYZER_SASSAFRAS",
-          "EOC_ANALYZER_BEECH"
+          "EOC_ANALYZER_SASSAFRAS_2",
+          "EOC_ANALYZER_BEECH",
+          "EOC_ANALYZER_BEECH_2"
         ]
       }
     ]
@@ -31,7 +35,7 @@
         { "not": { "u_know_recipe": { "context_val": "recipe_to_give" } } }
       ]
     },
-    "effect": [ { "u_learn_recipe": { "context_val": "recipe_to_give" } } ]
+    "effect": [ { "u_learn_recipe": { "context_val": "recipe_to_give" } }, { "u_message": "learned <context_val:recipe_to_give>" } ]
   },
   {
     "type": "effect_on_condition",
@@ -49,47 +53,8 @@
     },
     "effect": [
       { "u_learn_recipe": { "context_val": "recipe_to_give_1" } },
-      { "u_learn_recipe": { "context_val": "recipe_to_give_2" } }
+      { "u_learn_recipe": { "context_val": "recipe_to_give_2" } },
+      { "u_message": "learned <context_val:recipe_to_give_1> and <context_val:recipe_to_give_2>" }
     ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_ANALYZER_ABSTRACT_2x2",
-    "condition": {
-      "and": [
-        {
-          "or": [
-            { "not": { "u_has_item": { "context_val": "item_to_analyze_1" } } },
-            { "not": { "u_has_item": { "context_val": "item_to_analyze_2" } } }
-          ]
-        },
-        {
-          "or": [
-            { "not": { "u_know_recipe": { "context_val": "recipe_to_give_1" } } },
-            { "not": { "u_know_recipe": { "context_val": "recipe_to_give_2" } } }
-          ]
-        }
-      ]
-    },
-    "effect": [
-      { "u_learn_recipe": { "context_val": "recipe_to_give_1" } },
-      { "u_learn_recipe": { "context_val": "recipe_to_give_2" } }
-    ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_ANALYZER_ABSTRACT_2x1",
-    "condition": {
-      "and": [
-        {
-          "or": [
-            { "not": { "u_has_item": { "context_val": "item_to_analyze_1" } } },
-            { "not": { "u_has_item": { "context_val": "item_to_analyze_2" } } }
-          ]
-        },
-        { "not": { "u_know_recipe": { "context_val": "recipe_to_give" } } }
-      ]
-    },
-    "effect": [ { "u_learn_recipe": { "context_val": "recipe_to_give" } } ]
   }
 ]

--- a/effectoncondition/recipe_unlocks/fossil_genome_piece.json
+++ b/effectoncondition/recipe_unlocks/fossil_genome_piece.json
@@ -1,87 +1,103 @@
 [
   {
     "type": "effect_on_condition",
-    "id": "EOC_ANALYZER_TRIASSIC",
+    "id": "EOC_ANALYZER_JAPANESE_KNOTWEED",
+    "effect": [
+      {
+        "run_eoc_with": "EOC_ANALYZER_ABSTRACT_1x2",
+        "variables": {
+          "item_to_analyze": "japanese_knotweed_stem",
+          "recipe_to_give_1": "genome_japanese_knotweed",
+          "recipe_to_give_2": "seed_japanese_knotweed_clone"
+        }
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_ANALYZER_JAPANESE_KNOTWEED_2",
+    "effect": [
+      {
+        "run_eoc_with": "EOC_ANALYZER_ABSTRACT_1x2",
+        "variables": {
+          "item_to_analyze": "tissue_sample_japanese_knotweed",
+          "recipe_to_give_1": "genome_japanese_knotweed",
+          "recipe_to_give_2": "seed_japanese_knotweed_clone"
+        }
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_ANALYZER_BLACK_EYED_SUSAN",
     "effect": [
       {
         "run_eoc_with": "EOC_ANALYZER_ABSTRACT_1x1",
-        "variables": { "item_to_analyze": "fossil_triassic", "recipe_to_give": "genome_triassic_random" }
+        "variables": { "item_to_analyze": "tissue_sample_black_eyed_susan", "recipe_to_give": "genome_black_eyed_susan" }
       }
     ]
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_ANALYZER_JURASSIC",
+    "id": "EOC_ANALYZER_CHAMOMILE",
+    "effect": [
+      {
+        "run_eoc_with": "EOC_ANALYZER_ABSTRACT_1x2",
+        "variables": { "item_to_analyze": "chamomile", "recipe_to_give_1": "genome_chamomile", "recipe_to_give_2": "seed_chamomile_clone" }
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_ANALYZER_CHAMOMILE_2",
+    "effect": [
+      {
+        "run_eoc_with": "EOC_ANALYZER_ABSTRACT_1x2",
+        "variables": {
+          "item_to_analyze": "tissue_sample_chamomile",
+          "recipe_to_give_1": "genome_chamomile",
+          "recipe_to_give_2": "seed_chamomile_clone"
+        }
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_ANALYZER_SASSAFRAS",
     "effect": [
       {
         "run_eoc_with": "EOC_ANALYZER_ABSTRACT_1x1",
-        "variables": { "item_to_analyze": "fossil_jurassic", "recipe_to_give": "genome_jurassic_random" }
+        "variables": { "item_to_analyze": "tissue_sample_sassafras", "recipe_to_give": "genome_sassafras" }
       }
     ]
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_ANALYZER_CRETACEOUS",
+    "id": "EOC_ANALYZER_SASSAFRAS_2",
     "effect": [
       {
         "run_eoc_with": "EOC_ANALYZER_ABSTRACT_1x1",
-        "variables": { "item_to_analyze": "fossil_cretaceous", "recipe_to_give": "genome_cretaceous_random" }
+        "variables": { "item_to_analyze": "tissue_sample_sassafras", "recipe_to_give": "genome_sassafras" }
       }
     ]
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_ANALYZER_COELOPHYSIS_FOSSIL",
+    "id": "EOC_ANALYZER_BEECH",
     "effect": [
       {
-        "run_eoc_with": "EOC_ANALYZER_ABSTRACT_1x2",
-        "variables": {
-          "item_to_analyze": "genome_piece_coelophysis",
-          "recipe_to_give_1": "genome_coelophysis_fossil",
-          "recipe_to_give_2": "egg_clone_coelophysis"
-        }
+        "run_eoc_with": "EOC_ANALYZER_ABSTRACT_1x1",
+        "variables": { "item_to_analyze": "beech_nuts", "recipe_to_give": "genome_beech" }
       }
     ]
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_ANALYZER_DILOPHOSAURUS_FOSSIL",
+    "id": "EOC_ANALYZER_BEECH_2",
     "effect": [
       {
-        "run_eoc_with": "EOC_ANALYZER_ABSTRACT_1x2",
-        "variables": {
-          "item_to_analyze": "genome_piece_dilophosaurus",
-          "recipe_to_give_1": "genome_dilophosaurus_fossil",
-          "recipe_to_give_2": "egg_clone_dilophosaurus"
-        }
-      }
-    ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_ANALYZER_TYRANNOSAURUS_FOSSIL",
-    "effect": [
-      {
-        "run_eoc_with": "EOC_ANALYZER_ABSTRACT_1x2",
-        "variables": {
-          "item_to_analyze": "genome_piece_tyrannosaurus",
-          "recipe_to_give_1": "genome_tyrannosaurus_fossil",
-          "recipe_to_give_2": "egg_clone_tyrannosaurus"
-        }
-      }
-    ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_ANALYZER_XIPHACTINUS_FOSSIL",
-    "effect": [
-      {
-        "run_eoc_with": "EOC_ANALYZER_ABSTRACT_1x2",
-        "variables": {
-          "item_to_analyze": "genome_piece_xiphactinus",
-          "recipe_to_give_1": "genome_xiphactinus_fossil",
-          "recipe_to_give_2": "egg_clone_xiphactinus"
-        }
+        "run_eoc_with": "EOC_ANALYZER_ABSTRACT_1x1",
+        "variables": { "item_to_analyze": "tissue_sample_beech", "recipe_to_give": "genome_beech" }
       }
     ]
   }


### PR DESCRIPTION
i didn't actually found why the error happens, but it is something related to you having too many `item_to_analyze`. Solution is to remove `2x1` and `2x2` abstract, and if you happen to need to check two items, just run it twice
```json
  {
    "type": "effect_on_condition",
    "id": "EOC_ANALYZER_JAPANESE_KNOTWEED",
    "effect": [
      {
        "run_eoc_with": "EOC_ANALYZER_ABSTRACT_1x2",
        "variables": {
          "item_to_analyze": "japanese_knotweed_stem",
          "recipe_to_give_1": "genome_japanese_knotweed",
          "recipe_to_give_2": "seed_japanese_knotweed_clone"
        }
      }
    ]
  },
  {
    "type": "effect_on_condition",
    "id": "EOC_ANALYZER_JAPANESE_KNOTWEED_2",
    "effect": [
      {
        "run_eoc_with": "EOC_ANALYZER_ABSTRACT_1x2",
        "variables": {
          "item_to_analyze": "tissue_sample_japanese_knotweed",
          "recipe_to_give_1": "genome_japanese_knotweed",
          "recipe_to_give_2": "seed_japanese_knotweed_clone"
        }
      }
    ]
  },
  
  ```

before:
![image](https://github.com/Karol1223/CDDA-ProjectPangaea/assets/67688115/8ffc824d-72e2-4c7b-8598-a2547ea91ba1)


after: 
![image](https://github.com/Karol1223/CDDA-ProjectPangaea/assets/67688115/06e78c0e-edfd-4f76-bf92-1acf2c6472f1)
